### PR TITLE
Fixed the nonce issue with multiple transactions created quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ This page describes SDK API `v2.0.0`, for upgrade from `v1.x` please [follow the
 
 3. To run the end-to-end test, install [`gamma-cli`](https://github.com/orbs-network/gamma-cli)
 
-4. Run all tests with `npm run test`
+4. Run all tests (unit and e2e) with `npm run test`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "orbs-client-sdk",
-  "version": "2.3.1",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orbs-client-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "orbs-client-sdk",
   "main": "dist/orbs-client-sdk.js",
   "browser": "dist/orbs-client-sdk-web.js",

--- a/src/codec/OpRunQuery.ts
+++ b/src/codec/OpRunQuery.ts
@@ -52,7 +52,7 @@ export async function encodeRunQueryRequest(req: RunQueryRequest, signer: Signer
       query: new Protocol.QueryBuilder({
         protocolVersion: req.protocolVersion,
         virtualChainId: req.virtualChainId,
-        timestamp: Protocol.dateToUnixNano(req.timestamp),
+        timestamp: Protocol.dateToUnixNano(req.timestamp, 0),
         signer: new Protocol.SignerBuilder({
           scheme: 0,
           eddsa: new Protocol.EdDSA01SignerBuilder({

--- a/src/codec/OpSendTransaction.ts
+++ b/src/codec/OpSendTransaction.ts
@@ -23,6 +23,7 @@ export interface SendTransactionRequest {
   protocolVersion: number;
   virtualChainId: number;
   timestamp: Date;
+  nanoNonce: number; // nanoseconds in range 0 - 499,999 (that will still round down to 0 in milliseconds)
   networkType: NetworkType;
   contractName: string;
   methodName: string;
@@ -53,7 +54,7 @@ export async function encodeSendTransactionRequest(req: SendTransactionRequest, 
   const networkType = networkTypeEncode(req.networkType);
 
   // encode timestamp
-  const timestampNano = Protocol.dateToUnixNano(req.timestamp);
+  const timestampNano = Protocol.dateToUnixNano(req.timestamp, req.nanoNonce);
 
   // encode request
   const res = new Client.SendTransactionRequestBuilder({

--- a/src/codec/contract.test.ts
+++ b/src/codec/contract.test.ts
@@ -41,6 +41,7 @@ describe("Codec contract", () => {
           protocolVersion: jsonUnmarshalNumber(inputScenario.SendTransactionRequest.ProtocolVersion),
           virtualChainId: jsonUnmarshalNumber(inputScenario.SendTransactionRequest.VirtualChainId),
           timestamp: new Date(inputScenario.SendTransactionRequest.Timestamp),
+          nanoNonce: 0,
           networkType: inputScenario.SendTransactionRequest.NetworkType,
           contractName: inputScenario.SendTransactionRequest.ContractName,
           methodName: inputScenario.SendTransactionRequest.MethodName,

--- a/src/orbs/Client.test.ts
+++ b/src/orbs/Client.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 the orbs-client-sdk-javascript authors
+ * This file is part of the orbs-client-sdk-javascript library in the Orbs project.
+ *
+ * This source code is licensed under the MIT license found in the LICENSE file in the root directory of this source tree.
+ * The above notice should be included in all copies or substantial portions of the software.
+ */
+
+import { Client } from "./Client";
+import { LocalSigner, NetworkType, createAccount } from "..";
+
+test("multiple concurrent createTransaction with identical args have different txids", async () => {
+  const NUM_TX = 10;
+  
+  // generate a bunch of identical transactions at the same time
+  const client = new Client("http://endpoint.com", 42, NetworkType.NETWORK_TYPE_MAIN_NET, new LocalSigner(createAccount()));
+  let promises = [];
+  for (let i = 0; i < NUM_TX ; i++) {
+    promises.push(client.createTransaction("contract1", "method1", []));
+  }
+
+  // extract their tx ids
+  let txIds = [];
+  const values = await Promise.all(promises);
+  for (let i = 0; i < NUM_TX ; i++) {
+    const [tx, txId] = values[i];
+    txIds.push(txId);
+  }
+
+  // make sure all tx ids are different
+  for (let i = 0; i < NUM_TX; i++) {
+    for (let j = i+1; j < NUM_TX; j++) {
+      expect(txIds[i]).not.toEqual(txIds[j]);
+    }
+  }
+});
+
+test("bumpNanoNonce is always 0 - 499,999", () => {
+  const client = new Client("http://endpoint.com", 42, NetworkType.NETWORK_TYPE_MAIN_NET, new LocalSigner(createAccount()));
+  for (let i = 0; i < 2000000; i++) {
+    const n = client.bumpNanoNonce();
+    if (n < 0 || n > 499999) throw new Error(`bumpNanoNonce returned ${n} which is not 0 - 499,999`);
+  }
+});

--- a/src/orbs/Client.ts
+++ b/src/orbs/Client.ts
@@ -30,7 +30,18 @@ export const PROCESSOR_TYPE_NATIVE = 1;
 export const PROCESSOR_TYPE_JAVASCRIPT = 2;
 
 export class Client {
-  constructor(private endpoint: string, private virtualChainId: number, private networkType: NetworkType, private signer: Signer) {}
+  private nextNanoNonce: number;
+
+  constructor(private endpoint: string, private virtualChainId: number, private networkType: NetworkType, private signer: Signer) {
+    this.nextNanoNonce = 0;
+  }
+
+  bumpNanoNonce(): number {
+    const res = this.nextNanoNonce;
+    this.nextNanoNonce++;
+    if (this.nextNanoNonce > 499999) this.nextNanoNonce = 0;
+    return res;
+  }
 
   async createTransaction(contractName: string, methodName: string, inputArguments: Argument[]): Promise<[Uint8Array, string]> {
     const [req, rawTxId] = await encodeSendTransactionRequest(
@@ -38,6 +49,7 @@ export class Client {
         protocolVersion: PROTOCOL_VERSION,
         virtualChainId: this.virtualChainId,
         timestamp: new Date(),
+        nanoNonce: this.bumpNanoNonce(),
         networkType: this.networkType,
         contractName: contractName,
         methodName: methodName,

--- a/src/protocol/Protocol.ts
+++ b/src/protocol/Protocol.ts
@@ -9,8 +9,11 @@
 import { BaseBuilder } from "./Base";
 import { FieldTypes } from "membuffers";
 
-export function dateToUnixNano(date: Date): bigint {
-  return BigInt(date.getTime()) * BigInt(1000000);
+// nanoNonce = nanoseconds in range 0 - 499,999 (that will still round down to 0 in milliseconds)
+//  used to give different timestamps to transactions created in the same millisecond 
+export function dateToUnixNano(date: Date, nanoNonce: number): bigint {
+  if (nanoNonce < 0 || nanoNonce > 499999) throw new Error(`nanoNonce is ${nanoNonce} and must be 0 - 499,999`);
+  return (BigInt(date.getTime()) * BigInt(1000000)) + BigInt(nanoNonce);
 }
 
 export function unixNanoToDate(timestamp: bigint): Date {


### PR DESCRIPTION
Added an internal nonce field which is incrementing monotonously with every transaction created by the client. The nonce is limited at 499,999 and then rolls back to zero.

We add the nonce to the millisecond JavaScript Date timestamp.

Since the nonce is max 499,999 - when viewed in milliseconds, the increment to the nano timestamp will always be rounded down to zero and not make an impact.